### PR TITLE
Stop unnecessary lint/type checking for test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "lint:md": "remark .",
     "lint:ts": "tslint --project .",
     "format": "yarn prettier --write '**/*.{ts,js,json,md}'",
-    "pretest": "yarn lint:ts",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
ts-jest is doing everything necessary to perform type checking and more.

```sh
15:33 $ yarn test
yarn run v1.13.0
$ jest
 PASS  src/converters.test.ts
 PASS  src/invocationValidator.test.ts
 FAIL  src/executionHandler.test.ts
  ● Test suite failed to run

    TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
    src/initializeContext.ts:2:3 - error TS6133: 'CreateEntityOperation' is declared but its value is never read.

    2   CreateEntityOperation,
        ~~~~~~~~~~~~~~~~~~~~~
```

This raises a concern about using `ts-jest` to produce the JS that is running in tests vs. Babel to produce the JS that is shipping in the published module 🤔 