### PR TITLE
Clarify bunyan as devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
     "format": "yarn prettier --write '**/*.{ts,js,json,md}'",
     "test": "jest"
   },
-  "dependencies": {
-    "bunyan": "^1.8.12"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "@jupiterone/jupiter-managed-integration-sdk": "^19.2.0"
   },
@@ -39,6 +37,7 @@
     "@types/fs-extra": "^5.0.5",
     "@types/jest": "^24.0.0",
     "@types/node": "^10.12.20",
+    "bunyan": "^1.8.12",
     "fs-extra": "^7.0.1",
     "husky": "^1.3.1",
     "jest": "^24.0.0",


### PR DESCRIPTION
bunyan is only used by the `tools/execute.ts` script, to satisfy the requirement of providing a logger. bunyan is compatible with the interface required.