### PR TITLE
Fix local execution config for NVM and .env

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -15,7 +15,9 @@ debugging Jest tests][2].
       "type": "node",
       "request": "launch",
       "name": "Execute Integration Local",
+      "runtimeVersion": "8.10.0",
       "program": "${workspaceFolder}/tools/execute.ts",
+      "envFile": "${workspaceFolder}/.env",
       "preLaunchTask": "tsc: build - tsconfig.json",
       "sourceMaps": true,
       "outFiles": ["${workspaceFolder}/build/**/*.js"]


### PR DESCRIPTION
This is super handy for debugging local execution. It installs the environment from `.env` and also runs the correct version of Node that we currently deploy (Lambda 8.10).